### PR TITLE
added crucible_vlan resource

### DIFF
--- a/internal/api/caster_api_vlan.go
+++ b/internal/api/caster_api_vlan.go
@@ -1,0 +1,159 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+package api
+
+import (
+	"bytes"
+	"crucible_provider/internal/structs"
+	"crucible_provider/internal/util"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// -------------------- API Wrappers --------------------
+
+// CreateVlan wraps the acquire vlan POST call in caster API
+//
+// param command: A struct containing info on acquiring a vlan
+//
+// param m: A map containing configuration info for the provider
+//
+// Returns the ID of the view and error on failure or nil on success
+func CreateVlan(command *structs.VlanCreateCommand, m map[string]string) (*structs.Vlan, error) {
+	log.Printf("! At top of API wrapper to create vlan")
+
+	auth, err := util.GetAuth(m)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove unset fields from payload
+	payload := map[string]interface{}{
+		"projectId":   util.Ternary(command.ProjectId == "", nil, command.ProjectId),
+		"partitionId": util.Ternary(command.PartitionId == "", nil, command.PartitionId),
+		"tag":         util.Ternary(command.Tag == "", nil, command.Tag),
+		"vlanId":      util.Ternary(!command.VlanId.Valid, nil, command.VlanId.Int32),
+	}
+
+	log.Printf("! Creating vlan with payload %+v", payload)
+
+	asJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest("POST", util.GetCasterApiUrl(m)+"vlans/actions/acquire/", bytes.NewBuffer(asJSON))
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Authorization", "Bearer "+auth)
+	request.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	status := response.StatusCode
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("Caster API returned with status code %d when creating vlan", status)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Body)
+	asStr := buf.String()
+	defer response.Body.Close()
+
+	vlan := &structs.Vlan{}
+	err = json.Unmarshal([]byte(asStr), vlan)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return vlan, nil
+}
+
+// ReadVlan wraps the caster API call to read the fields of a vlan
+//
+// Param id: the id of the vlan to read
+//
+// param m: A map containing configuration info for the provider
+//
+// Returns error on failure or the vlan on success
+func ReadVlan(id string, m map[string]string) (*structs.Vlan, error) {
+	auth, err := util.GetAuth(m)
+	if err != nil {
+		return nil, err
+	}
+
+	url := util.GetCasterApiUrl(m) + "vlans/" + id
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Authorization", "Bearer "+auth)
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	status := response.StatusCode
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("Caster API returned with status code %d when reading vlan", status)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Body)
+	asStr := buf.String()
+	defer response.Body.Close()
+
+	vlan := &structs.Vlan{}
+
+	err = json.Unmarshal([]byte(asStr), vlan)
+	if err != nil {
+		log.Printf("! Error unmarshaling in read vlan")
+		return nil, err
+	}
+
+	return vlan, nil
+}
+
+// DeleteVlan wraps the caster API release vlan call
+//
+// Param id: The id of the vlan to release back into the pool
+//
+// param m: A map containing configuration info for the provider
+//
+// Returns error on failure or nil on success
+func DeleteVlan(id string, m map[string]string) error {
+	auth, err := util.GetAuth(m)
+	if err != nil {
+		return err
+	}
+
+	url := util.GetCasterApiUrl(m) + "vlans/" + id + "/actions/release"
+	request, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Add("Authorization", "Bearer "+auth)
+	client := &http.Client{}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+
+	status := response.StatusCode
+	if status != http.StatusOK {
+		return fmt.Errorf("Caster API returned with status code %d when deleting vlan", status)
+	}
+	return nil
+}

--- a/internal/api/player_api_application.go
+++ b/internal/api/player_api_application.go
@@ -37,7 +37,7 @@ func CreateApps(apps *[]*structs.AppInfo, m map[string]string, viewID string) er
 			return err
 		}
 
-		url := m["player_api_url"] + "views/" + viewID + "/applications"
+		url := util.GetPlayerApiUrl(m) + "views/" + viewID + "/applications"
 		log.Printf("! creating app. url: %v", url)
 		log.Printf("! Payload: %+v", app)
 		request, err := http.NewRequest("POST", url, bytes.NewBuffer(asJSON))
@@ -82,7 +82,7 @@ func UpdateApps(apps *[]*structs.AppInfo, m map[string]string) error {
 			return err
 		}
 
-		url := m["player_api_url"] + "applications/" + app.ID
+		url := util.GetPlayerApiUrl(m) + "applications/" + app.ID
 		request, err := http.NewRequest("PUT", url, bytes.NewBuffer(asJSON))
 		if err != nil {
 			return err
@@ -114,7 +114,7 @@ func DeleteApps(ids *[]string, m map[string]string) error {
 	}
 
 	for i, id := range *ids {
-		url := m["player_api_url"] + "applications/" + id
+		url := util.GetPlayerApiUrl(m) + "applications/" + id
 		request, err := http.NewRequest("DELETE", url, nil)
 		if err != nil {
 			return err
@@ -166,7 +166,7 @@ func UpdateAppInstance(inst structs.AppInstance, teamID string, m map[string]str
 		return err
 	}
 
-	url := m["player_api_url"] + "application-instances/" + inst.ID
+	url := util.GetPlayerApiUrl(m) + "application-instances/" + inst.ID
 	request, err := http.NewRequest("PUT", url, bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func AddApplication(appID, teamID string, displayOrder float64, m map[string]str
 		return "", err
 	}
 
-	url := m["player_api_url"] + "teams/" + teamID + "/application-instances"
+	url := util.GetPlayerApiUrl(m) + "teams/" + teamID + "/application-instances"
 	request, err := http.NewRequest("POST", url, bytes.NewBuffer(asJSON))
 	if err != nil {
 		return "", err
@@ -268,7 +268,7 @@ func DeleteAppInstances(toDelete *[]string, m map[string]string) error {
 	}
 
 	for i, id := range *toDelete {
-		url := m["player_api_url"] + "application-instances/" + id
+		url := util.GetPlayerApiUrl(m) + "application-instances/" + id
 		request, err := http.NewRequest("DELETE", url, nil)
 		if err != nil {
 			return err
@@ -306,7 +306,7 @@ func readApps(id string, m map[string]string) (*[]structs.AppInfo, error) {
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "views/" + id + "/applications"
+	url := util.GetPlayerApiUrl(m) + "views/" + id + "/applications"
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -345,7 +345,7 @@ func getTeamAppInstances(teamID string, m map[string]string) (*[]structs.AppInst
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "teams/" + teamID + "/application-instances"
+	url := util.GetPlayerApiUrl(m) + "teams/" + teamID + "/application-instances"
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/internal/api/player_api_application_template.go
+++ b/internal/api/player_api_application_template.go
@@ -44,7 +44,7 @@ func CreateAppTemplate(template *structs.AppTemplate, m map[string]string) (stri
 
 	log.Printf("! Creating template with payload %+v", payload)
 	// Create the template
-	url := m["player_api_url"] + "application-templates"
+	url := util.GetPlayerApiUrl(m) + "application-templates"
 	request, err := http.NewRequest("POST", url, bytes.NewBuffer(asJSON))
 	if err != nil {
 		return "", err
@@ -130,7 +130,7 @@ func AppTemplateUpdate(id string, template *structs.AppTemplate, m map[string]st
 	}
 
 	// Update the template
-	url := m["player_api_url"] + "application-templates/" + id
+	url := util.GetPlayerApiUrl(m) + "application-templates/" + id
 	request, err := http.NewRequest("PUT", url, bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func DeleteAppTemplate(id string, m map[string]string) error {
 		return nil
 	}
 
-	url := m["player_api_url"] + "application-templates/" + id
+	url := util.GetPlayerApiUrl(m) + "application-templates/" + id
 	request, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return err
@@ -205,7 +205,7 @@ func getAppTemplateByID(id string, m map[string]string) (*http.Response, error) 
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "application-templates/" + id
+	url := util.GetPlayerApiUrl(m) + "application-templates/" + id
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/internal/api/player_api_team.go
+++ b/internal/api/player_api_team.go
@@ -58,7 +58,7 @@ func CreateTeams(teams *[]*structs.TeamInfo, viewID string, m map[string]string)
 
 		log.Printf("! Team being created: %+v", asMap)
 
-		url := m["player_api_url"] + "views/" + viewID + "/teams"
+		url := util.GetPlayerApiUrl(m) + "views/" + viewID + "/teams"
 		request, err := http.NewRequest("POST", url, bytes.NewBuffer(asJSON))
 		if err != nil {
 			return err
@@ -146,7 +146,7 @@ func UpdateTeams(teams *[]*structs.TeamInfo, m map[string]string) error {
 			return err
 		}
 
-		url := m["player_api_url"] + "teams/" + team.ID.(string)
+		url := util.GetPlayerApiUrl(m) + "teams/" + team.ID.(string)
 		log.Printf("! Updating team. URL: %v", url)
 		log.Printf("! Updating team. Payload: %+v", team)
 		request, err := http.NewRequest("PUT", url, bytes.NewBuffer(asJSON))
@@ -184,7 +184,7 @@ func DeleteTeams(ids *[]string, m map[string]string) error {
 	}
 
 	for i, id := range *ids {
-		url := m["player_api_url"] + "teams/" + id
+		url := util.GetPlayerApiUrl(m) + "teams/" + id
 		request, err := http.NewRequest("DELETE", url, nil)
 		if err != nil {
 			return err
@@ -222,7 +222,7 @@ func AddPermissionsToTeam(teams *[]*structs.TeamInfo, m map[string]string) error
 	for _, team := range *teams {
 		log.Printf("! Adding permission to team %+v", team)
 		for _, perm := range team.Permissions {
-			url := m["player_api_url"] + "teams/" + team.ID.(string) + "/permissions/" + perm
+			url := util.GetPlayerApiUrl(m) + "teams/" + team.ID.(string) + "/permissions/" + perm
 			request, err := http.NewRequest("POST", url, nil)
 			if err != nil {
 				return err
@@ -265,7 +265,7 @@ func UpdateTeamPermissions(toAdd, toRemove map[string][]string, m map[string]str
 	// Add permissions
 	for team := range toAdd {
 		for _, perm := range toAdd[team] {
-			url := m["player_api_url"] + "teams/" + team + "/permissions/" + perm
+			url := util.GetPlayerApiUrl(m) + "teams/" + team + "/permissions/" + perm
 			request, err := http.NewRequest("POST", url, nil)
 			if err != nil {
 				return err
@@ -289,7 +289,7 @@ func UpdateTeamPermissions(toAdd, toRemove map[string][]string, m map[string]str
 	// Remove permissions
 	for team := range toRemove {
 		for _, perm := range toRemove[team] {
-			url := m["player_api_url"] + "teams/" + team + "/permissions/" + perm
+			url := util.GetPlayerApiUrl(m) + "teams/" + team + "/permissions/" + perm
 			request, err := http.NewRequest("DELETE", url, nil)
 			if err != nil {
 				return err
@@ -320,7 +320,7 @@ func GetRoleByID(role string, m map[string]string) (string, error) {
 		return "", err
 	}
 
-	url := m["player_api_url"] + "roles/" + role
+	url := util.GetPlayerApiUrl(m) + "roles/" + role
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -368,7 +368,7 @@ func readTeams(viewID string, m map[string]string) (*[]structs.TeamInfo, error) 
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "views/" + viewID + "/teams"
+	url := util.GetPlayerApiUrl(m) + "views/" + viewID + "/teams"
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func readTeams(viewID string, m map[string]string) (*[]structs.TeamInfo, error) 
 
 // Returns the ID of the role with the given name
 func getRoleByName(role, auth string, m map[string]string) (string, error) {
-	url := m["player_api_url"] + "roles/name/" + role
+	url := util.GetPlayerApiUrl(m) + "roles/name/" + role
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err

--- a/internal/api/player_api_user.go
+++ b/internal/api/player_api_user.go
@@ -30,7 +30,7 @@ func RemoveUsers(teamsToUsers map[string][]string, m map[string]string) error {
 
 	for team := range teamsToUsers {
 		for _, user := range teamsToUsers[team] {
-			url := m["player_api_url"] + "teams/" + team + "/users/" + user
+			url := util.GetPlayerApiUrl(m) + "teams/" + team + "/users/" + user
 			request, err := http.NewRequest("DELETE", url, nil)
 			request.Header.Add("Authorization", "Bearer "+auth)
 			client := &http.Client{}
@@ -65,7 +65,7 @@ func AddUsersToTeam(users *[]string, team string, m map[string]string) error {
 	}
 
 	for _, user := range *users {
-		url := m["player_api_url"] + "teams/" + team + "/users/" + user
+		url := util.GetPlayerApiUrl(m) + "teams/" + team + "/users/" + user
 		request, err := http.NewRequest("POST", url, nil)
 		request.Header.Add("Authorization", "Bearer "+auth)
 		client := http.Client{}
@@ -102,7 +102,7 @@ func SetUserRole(teamID, viewID string, user structs.UserInfo, m map[string]stri
 	}
 
 	// Find the ID of the relevant TeamMembership
-	url := m["player_api_url"] + "users/" + user.ID + "/views/" + viewID + "/team-memberships"
+	url := util.GetPlayerApiUrl(m) + "users/" + user.ID + "/views/" + viewID + "/team-memberships"
 	id, err := findMembershipID(url, teamID, auth)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func SetUserRole(teamID, viewID string, user structs.UserInfo, m map[string]stri
 		return err
 	}
 
-	url = m["player_api_url"] + "team-memberships/" + id
+	url = util.GetPlayerApiUrl(m) + "team-memberships/" + id
 	request, err := http.NewRequest("PUT", url, bytes.NewBuffer(payload))
 	request.Header.Add("Authorization", "Bearer "+auth)
 	request.Header.Set("Content-Type", "application/json")
@@ -172,7 +172,7 @@ func CreateUser(user structs.PlayerUser, m map[string]string) error {
 		return err
 	}
 
-	url := m["player_api_url"] + "users"
+	url := util.GetPlayerApiUrl(m) + "users"
 	request, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
 	if err != nil {
 		return err
@@ -272,7 +272,7 @@ func UpdateUser(user structs.PlayerUser, m map[string]string) error {
 		return err
 	}
 
-	url := m["player_api_url"] + "users/" + user.ID
+	url := util.GetPlayerApiUrl(m) + "users/" + user.ID
 	request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(payload))
 	if err != nil {
 		return err
@@ -306,7 +306,7 @@ func DeleteUser(id string, m map[string]string) error {
 		return err
 	}
 
-	url := m["player_api_url"] + "users/" + id
+	url := util.GetPlayerApiUrl(m) + "users/" + id
 	request, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return err
@@ -343,7 +343,7 @@ func addUser(userID, teamID string, m map[string]string) error {
 	}
 
 	// Add the user to their team
-	url := m["player_api_url"] + "teams/" + teamID + "/users/" + userID
+	url := util.GetPlayerApiUrl(m) + "teams/" + teamID + "/users/" + userID
 	request, err := http.NewRequest("POST", url, nil)
 	request.Header.Add("Authorization", "Bearer "+auth)
 	client := &http.Client{}
@@ -401,7 +401,7 @@ func findMembershipID(url, teamID, auth string) (string, error) {
 
 // Returns the teamMembership with the given id
 func getMembership(id, auth string, m map[string]string) (string, error) {
-	url := m["player_api_url"] + "team-memberships/" + id
+	url := util.GetPlayerApiUrl(m) + "team-memberships/" + id
 
 	request, err := http.NewRequest("GET", url, nil)
 	request.Header.Add("Authorization", "Bearer "+auth)
@@ -439,7 +439,7 @@ func getUsersInTeam(teamID, viewID string, m map[string]string) ([]structs.UserI
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "teams/" + teamID + "/users"
+	url := util.GetPlayerApiUrl(m) + "teams/" + teamID + "/users"
 	request, err := http.NewRequest("GET", url, nil)
 	request.Header.Add("Authorization", "Bearer "+auth)
 	client := http.Client{}
@@ -471,7 +471,7 @@ func getUsersInTeam(teamID, viewID string, m map[string]string) ([]structs.UserI
 	for _, user := range *users {
 		userID := user["id"].(string)
 		// Get team membership by id, assign it to RoleID field
-		url = m["player_api_url"] + "users/" + userID + "/views/" + viewID + "/team-memberships"
+		url = util.GetPlayerApiUrl(m) + "users/" + userID + "/views/" + viewID + "/team-memberships"
 		id, err := findMembershipID(url, teamID, auth)
 		if err != nil {
 			return nil, err
@@ -498,7 +498,7 @@ func getUserByID(id string, m map[string]string) (*http.Response, error) {
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "users/" + id
+	url := util.GetPlayerApiUrl(m) + "users/" + id
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/internal/api/player_api_view.go
+++ b/internal/api/player_api_view.go
@@ -45,7 +45,7 @@ func CreateView(view *structs.ViewInfo, m map[string]string) (string, error) {
 		return "", err
 	}
 
-	request, err := http.NewRequest("POST", m["player_api_url"]+"views", bytes.NewBuffer(asJSON))
+	request, err := http.NewRequest("POST", util.GetPlayerApiUrl(m)+"views", bytes.NewBuffer(asJSON))
 	if err != nil {
 		return "", err
 	}
@@ -146,7 +146,7 @@ func UpdateView(view *structs.ViewInfo, m map[string]string, id string) error {
 		return err
 	}
 
-	url := m["player_api_url"] + "views/" + id
+	url := util.GetPlayerApiUrl(m) + "views/" + id
 	log.Printf("! url: %v", url)
 	request, err := http.NewRequest("PUT", url, bytes.NewBuffer(asJSON))
 	if err != nil {
@@ -184,7 +184,7 @@ func DeleteView(id string, m map[string]string) error {
 		return err
 	}
 
-	url := m["player_api_url"] + "views/" + id
+	url := util.GetPlayerApiUrl(m) + "views/" + id
 	request, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return err
@@ -225,7 +225,7 @@ func getViewByID(id string, m map[string]string) (*http.Response, error) {
 		return nil, err
 	}
 
-	url := m["player_api_url"] + "views/" + id
+	url := util.GetPlayerApiUrl(m) + "views/" + id
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/internal/api/vm_api.go
+++ b/internal/api/vm_api.go
@@ -37,7 +37,7 @@ func CreateVM(requestBody *structs.VMInfo, m map[string]string) error {
 	}
 
 	// Set up the HTTP request
-	req, err := http.NewRequest("POST", m["vm_api_url"]+"vms", bytes.NewBuffer(asJSON))
+	req, err := http.NewRequest("POST", util.GetVmApiUrl(m)+"vms", bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func GetVMInfo(id string, m map[string]string) (*structs.VMInfo, error) {
 // Returns some error on failure and nil on success
 func UpdateVM(requestBody *structs.VMInfo, id string, m map[string]string) error {
 	log.Printf("! In update API wrapper")
-	url := m["vm_api_url"] + "vms/" + id
+	url := util.GetVmApiUrl(m) + "vms/" + id
 
 	// Get auth token
 	auth, err := util.GetAuth(m)
@@ -153,7 +153,7 @@ func UpdateVM(requestBody *structs.VMInfo, id string, m map[string]string) error
 // returns error on failure or nil on success
 func DeleteVM(id string, m map[string]string) error {
 	log.Printf("! In delete API wrapper")
-	url := m["vm_api_url"] + "vms/" + id
+	url := util.GetVmApiUrl(m) + "vms/" + id
 
 	// Get auth token
 	auth, err := util.GetAuth(m)
@@ -222,7 +222,7 @@ func RemoveVMFromTeams(teams *[]string, vm string, m map[string]string) error {
 	log.Printf("! In Remove VM from Team API wrapper")
 
 	for _, team := range *teams {
-		url := m["vm_api_url"] + "teams/" + team + "/vms/" + vm
+		url := util.GetVmApiUrl(m) + "teams/" + team + "/vms/" + vm
 		req, err := http.NewRequest("DELETE", url, nil)
 		if err != nil {
 			return err
@@ -267,7 +267,7 @@ func AddVMToTeams(teams *[]string, vm string, m map[string]string) error {
 	log.Printf("! In add team to VM API wrapper")
 
 	for _, team := range *teams {
-		url := m["vm_api_url"] + "teams/" + team + "/vms/" + vm
+		url := util.GetVmApiUrl(m) + "teams/" + team + "/vms/" + vm
 		req, err := http.NewRequest("POST", url, nil)
 		if err != nil {
 			return err
@@ -307,7 +307,7 @@ func getVMByID(id string, m map[string]string) (*http.Response, error) {
 	}
 
 	// Set up the request
-	url := m["vm_api_url"] + "vms/" + id
+	url := util.GetVmApiUrl(m) + "vms/" + id
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.Printf("! In getVMByID, error setting up request")

--- a/internal/provider/caster_vlan_server.go
+++ b/internal/provider/caster_vlan_server.go
@@ -1,0 +1,167 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+package provider
+
+import (
+	"crucible_provider/internal/api"
+	"crucible_provider/internal/structs"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func casterVlan() *schema.Resource {
+	return &schema.Resource{
+		Create: casterVlanCreate,
+		Read:   casterVlanRead,
+		Delete: casterVlanDelete,
+
+		Schema: map[string]*schema.Schema{
+			"partition_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"project_id"},
+				ForceNew:      true,
+				Computed:      true,
+			},
+			"pool_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"vlan_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+// Get view properties from d
+// Call API to create view
+// If no error, set local state
+// Call read to make sure everything worked
+func casterVlanCreate(d *schema.ResourceData, m interface{}) error {
+	if m == nil {
+		return fmt.Errorf("error configuring provider")
+	}
+
+	vlanCreateCommand := &structs.VlanCreateCommand{
+		ProjectId:   d.Get("project_id").(string),
+		PartitionId: d.Get("partition_id").(string),
+		Tag:         d.Get("tag").(string),
+	}
+
+	vlanId, vlanIdExists := d.GetOk("vlan_id")
+
+	if vlanIdExists {
+		vlanCreateCommand.VlanId = sql.NullInt32{Int32: int32(vlanId.(int)), Valid: true}
+	}
+
+	casted := m.(map[string]string)
+	vlan, err := api.CreateVlan(vlanCreateCommand, casted)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(vlan.Id)
+
+	err = d.Set("vlan_id", vlan.VlanId)
+	if err != nil {
+		return err
+	}
+
+	// Set local state
+	err = d.Set("vlan_id", vlan.VlanId)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("pool_id", vlan.PoolId)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("partition_id", vlan.PartitionId)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("tag", vlan.Tag)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("! Vlan created with ID %s", d.Id())
+	return nil
+}
+
+// Check if vlan exists. If not, set id to "" and return nil
+// Read vlan info from API
+// Use it to update local state
+func casterVlanRead(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	casted := m.(map[string]string)
+
+	// Call API to read state of the vlan
+	vlan, err := api.ReadVlan(id, casted)
+	if err != nil {
+		return err
+	}
+
+	if !vlan.InUse {
+		d.SetId("")
+		return nil
+	}
+
+	// Set local state
+	err = d.Set("vlan_id", vlan.VlanId)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("pool_id", vlan.PoolId)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("partition_id", vlan.PartitionId)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("tag", vlan.Tag)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete vlan
+// Call API release function. Return nil on success or some error on failure
+func casterVlanDelete(d *schema.ResourceData, m interface{}) error {
+	if m == nil {
+		return fmt.Errorf("error configuring provider")
+	}
+
+	id := d.Id()
+	casted := m.(map[string]string)
+
+	return api.DeleteVlan(id, casted)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,6 +17,7 @@ func Provider() *schema.Provider {
 			"crucible_player_view":                 playerView(),
 			"crucible_player_application_template": applicationTemplate(),
 			"crucible_player_user":                 user(),
+			"crucible_vlan":                        casterVlan(),
 		},
 		Schema: map[string]*schema.Schema{
 			"username": {
@@ -61,6 +62,13 @@ func Provider() *schema.Provider {
 					return os.Getenv("SEI_CRUCIBLE_PLAYER_API_URL"), nil
 				},
 			},
+			"caster_api_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				DefaultFunc: func() (interface{}, error) {
+					return os.Getenv("SEI_CRUCIBLE_CASTER_API_URL"), nil
+				},
+			},
 			"client_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -89,11 +97,12 @@ func config(r *schema.ResourceData) (interface{}, error) {
 	playerTok := r.Get("token_url")
 	vmAPI := r.Get("vm_api_url")
 	playerAPI := r.Get("player_api_url")
+	casterAPI := r.Get("caster_api_url")
 	id := r.Get("client_id")
 	sec := r.Get("client_secret")
 
 	if user == nil || pass == nil || auth == nil || playerTok == nil || vmAPI == nil || id == nil || sec == nil ||
-		playerAPI == nil {
+		playerAPI == nil || casterAPI == nil {
 		return nil, nil
 	}
 
@@ -104,6 +113,7 @@ func config(r *schema.ResourceData) (interface{}, error) {
 	m["player_token_url"] = playerTok.(string)
 	m["vm_api_url"] = vmAPI.(string)
 	m["player_api_url"] = playerAPI.(string)
+	m["caster_api_url"] = casterAPI.(string)
 	m["client_id"] = id.(string)
 	m["client_secret"] = sec.(string)
 	return m, nil

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"crucible_provider/internal/util"
+	"database/sql"
 	"fmt"
 	"log"
 	"strconv"
@@ -385,4 +386,21 @@ type PlayerUser struct {
 	Name          string
 	Role          interface{} `json:"roleId"`
 	IsSystemAdmin bool
+}
+
+type Vlan struct {
+	Id          string
+	PoolId      string
+	PartitionId string
+	VlanId      int
+	InUse       bool
+	Reserved    bool
+	Tag         string
+}
+
+type VlanCreateCommand struct {
+	ProjectId   string
+	PartitionId string
+	Tag         string
+	VlanId      sql.NullInt32
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -5,6 +5,8 @@ package util
 
 import (
 	"context"
+	"log"
+	"strings"
 
 	"golang.org/x/oauth2"
 )
@@ -77,4 +79,41 @@ func StrSliceContains(arr *[]string, str string) bool {
 		}
 	}
 	return false
+}
+
+// Returns the normalized url for the player api
+func GetPlayerApiUrl(m map[string]string) string {
+	return GetApiUrl(m, "player_api_url")
+}
+
+// Returns the normalized url for the vm api
+func GetVmApiUrl(m map[string]string) string {
+	return GetApiUrl(m, "vm_api_url")
+}
+
+// Returns the normalized url for the caster api
+func GetCasterApiUrl(m map[string]string) string {
+	return GetApiUrl(m, "caster_api_url")
+}
+
+// GetApiUrl returns a url from the settings map, normalized to end in /api/
+//
+// param m: The settings map
+//
+// param urlName: The name of the url setting in the map
+//
+// Returns empty string is urlName is not found in the map
+func GetApiUrl(m map[string]string, urlName string) string {
+	log.Printf("! Getting API Url for %s", urlName)
+	if url, exists := m[urlName]; exists {
+		log.Printf("! URL = %s", url)
+		url = strings.TrimSuffix(url, "/")
+		url = strings.TrimSuffix(url, "/api")
+		url = url + "/api/"
+		log.Printf("! Normalized URL = %s", url)
+		return url
+	}
+
+	log.Printf("! URL not found")
+	return ""
 }


### PR DESCRIPTION
Added a crucible_vlan resource to acquire and release VLANs from the Caster API. See README for details.

- **NEW SETTING**: caster_api_url or SEI_CRUCIBLE_CASTER_API_URL as an env var. This must be set to the url of the Caster API in order to use the crucible_vlan resource. Should be set in the Caster API container to pass through the env var to the provider.
- **REQUIRED CONFIGURATION**: The oauth2/oidc client used by the provider in an environment will need the proper scope(s) added to access the Caster API. Additionally, the user used by the client will need to be a System Admin in Caster.
- all url settings are now normalized and will work with any combination of including or not including trailing slashes or /api. The following examples will all properly resolve to https://caster.example.com/api/ within the provider
  - https://caster.example.com/api/
  - https://caster.example.com/api
  - https://caster.example.com/
  - https://caster.example.com