### PR TITLE
added embeddable property to crucible_player_virtual_machine

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ resource "crucible_player_virtual_machine" "guacamole_example" {
 		username = "user"
 		password = "example"
 	}
+	embeddable = false
 }
 
 resource "crucible_player_virtual_machine" "proxmox_example" {
@@ -60,6 +61,7 @@ resource "crucible_player_virtual_machine" "proxmox_example" {
 		id = 100
 		node = "pve"
 	}
+	embeddable = true
 }
 ```
 
@@ -84,9 +86,12 @@ The name of the resource type - the first string after the word "resource" - mus
   - password: An optional password to connect with
 
 - proxmox_vm_info: An optional object with additional metadata required for a virtual machine on a Proxmox hypervisor
+
   - id: The integer id of the virtual machine within Proxmox
   - node: The name of the node that the virtual machine is running on
   - type: The type of virtual machine (QEMU, LXC). If omitted, defaults to QEMU
+
+- embeddable: An optional boolean field denoting if the UI should allow opening of this virtual machine's console in the embedded view. If false, the UI should only allow opening the console in a new tab. Defaults to true.
 
 ## Player Views
 

--- a/internal/api/vm_api.go
+++ b/internal/api/vm_api.go
@@ -358,11 +358,19 @@ func unpackResponse(resp *http.Response) *structs.VMInfo {
 		proxmoxPtr = structs.ProxmoxInfoFromMap(proxmox.(map[string]interface{}))
 	}
 
+	// set defaults if defaultUrl and embeddable don't exist (older api versions)
 	defaultUrl := false
 	defaultUrlObj := asMap["defaultUrl"]
 
 	if defaultUrlObj != nil {
 		defaultUrl = defaultUrlObj.(bool)
+	}
+
+	embeddable := true
+	embeddableObj := asMap["embeddable"]
+
+	if embeddableObj != nil {
+		embeddable = embeddableObj.(bool)
 	}
 
 	// Unpack the map into a struct. We *should* be able to unmarshal right into the struct, but it's refusing
@@ -374,6 +382,7 @@ func unpackResponse(resp *http.Response) *structs.VMInfo {
 		Name:       asMap["name"].(string),
 		TeamIDs:    *teamsConverted,
 		UserID:     asMap["userId"],
+		Embeddable: embeddable,
 		Connection: connectionPtr,
 		Proxmox:    proxmoxPtr,
 	}

--- a/internal/provider/player_virtual_machine_server.go
+++ b/internal/provider/player_virtual_machine_server.go
@@ -72,6 +72,11 @@ func playerVirtualMachine() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"embeddable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"console_connection_info": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -210,6 +215,7 @@ func playerVirtualMachineCreate(d *schema.ResourceData, m interface{}) error {
 		Name:       d.Get("name").(string),
 		TeamIDs:    *convertedTeamIDs,
 		UserID:     uid,
+		Embeddable: d.Get("embeddable").(bool),
 		Connection: connection,
 		Proxmox:    proxmox,
 	}
@@ -310,6 +316,10 @@ func playerVirtualMachineRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	err = d.Set("team_ids", info.TeamIDs)
+	if err != nil {
+		return err
+	}
+	err = d.Set("embeddable", info.Embeddable)
 	if err != nil {
 		return err
 	}
@@ -417,6 +427,13 @@ func playerVirtualMachineUpdate(d *schema.ResourceData, m interface{}) error {
 		url = d.Get("url").(string)
 	}
 
+	var embeddable bool
+	if d.Get("embeddable").(bool) {
+		embeddable = d.Get("embeddable").(bool)
+	} else {
+		embeddable = true
+	}
+
 	connectionGeneric := d.Get("console_connection_info").([]interface{})
 	var connection *structs.ConsoleConnection
 	if len(connectionGeneric) != 0 {
@@ -436,6 +453,7 @@ func playerVirtualMachineUpdate(d *schema.ResourceData, m interface{}) error {
 		Name:       d.Get("name").(string),
 		TeamIDs:    []string{""},
 		UserID:     uid,
+		Embeddable: embeddable,
 		Connection: connection,
 		Proxmox:    proxmox,
 	}

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -22,6 +22,7 @@ type VMInfo struct {
 	Name       string
 	TeamIDs    []string
 	UserID     interface{}
+	Embeddable bool
 	Connection *ConsoleConnection `json:"consoleConnectionInfo"` // Use a pointer so this can be set to nil
 	Proxmox    *ProxmoxInfo       `json:"proxmoxVmInfo"`         // Use a pointer so this can be set to nil
 }


### PR DESCRIPTION
- Adds support for the Embeddable property of the crucible_player_virtual_machine resource. If set to false, the UI should not allow the VM to be opened in the embedded console view and always open it in a new tab.