### PR TITLE
Add way for user to define the scopes used

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ SEI_CRUCIBLE_AUTH_URL=<the url to the authentication service>
 SEI_CRUCIBLE_TOK_URL=<the url where you get your player authentication token>
 SEI_CRUCIBLE_CLIENT_ID=<your client ID for authentication>
 SEI_CRUCIBLE_CLIENT_SECRET=<your client secret for authentication>
+SEI_CRUCIBLE_CLIENT_SCOPES='["<Scopes for authorising users to services>"]' 
 SEI_CRUCIBLE_VM_API_URL=<the url to the VM API>
 SEI_CRUCIBLE_PLAYER_API_URL=<the url to the Player API>
 SEI_CRUCIBLE_CASTER_API_URL=<the url to the Caster API>
-SEI_CRUCIBLE_CLIENT_SCOPES='["caster", "vm", "player"]' <Scopes for authorising users to services>
 ```
 Alternatively you can set the variables in your main.tf
 
@@ -23,10 +23,12 @@ provider "crucible" {
   password       = "<your password>"
   auth_url       = "<the url to the authentication service>"
   token_url      = "<the url where you get your player authentication token>"
-  caster_api_url = "https://caster-api.vcrucible.ixtp.local"
-  client_id = "<your client ID for authentication>"
-  client_secret = "<your client secret for authentication>"
-  client_scopes = ["caster", "vm", "player"] <Scopes for authorising users to services>
+  client_id      = "<your client ID for authentication>"
+  client_secret  = "<your client secret for authentication>"
+  client_scopes  = ["<Scopes for authorising users to services>"] 
+  vm_api_url     = "<the url to the VM API>"
+  player_api_url = "<the url to the Player API>"
+  caster_api_url = "<the url to the Caster API>"
 }
 ```
 ## Virtual Machines

--- a/README.md
+++ b/README.md
@@ -12,8 +12,23 @@ SEI_CRUCIBLE_CLIENT_ID=<your client ID for authentication>
 SEI_CRUCIBLE_CLIENT_SECRET=<your client secret for authentication>
 SEI_CRUCIBLE_VM_API_URL=<the url to the VM API>
 SEI_CRUCIBLE_PLAYER_API_URL=<the url to the Player API>
+SEI_CRUCIBLE_CASTER_API_URL=<the url to the Caster API>
+SEI_CRUCIBLE_CLIENT_SCOPES='["caster", "vm", "player"]' <Scopes for authorising users to services>
 ```
+Alternatively you can set the variables in your main.tf
 
+```hcl
+provider "crucible" {
+  username       = "<your username>"
+  password       = "<your password>"
+  auth_url       = "<the url to the authentication service>"
+  token_url      = "<the url where you get your player authentication token>"
+  caster_api_url = "https://caster-api.vcrucible.ixtp.local"
+  client_id = "<your client ID for authentication>"
+  client_secret = "<your client secret for authentication>"
+  client_scopes = ["caster", "vm", "player"] <Scopes for authorising users to services>
+}
+```
 ## Virtual Machines
 
 The provider can interact with Crucible's VM API in order to manage virtual machine resources. VMs can be created, read, updated, and destroyed using Terraform with this provider. Some example configs for single virtual machines are defined below.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"os"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -83,6 +84,16 @@ func Provider() *schema.Provider {
 					return os.Getenv("SEI_CRUCIBLE_CLIENT_SECRET"), nil
 				},
 			},
+			"client_scopes": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required: true,
+				DefaultFunc: func() (interface{}, error) {
+					return os.Getenv("SEI_CRUCIBLE_CLIENT_SCOPES"), nil
+				},
+			},
 		},
 		ConfigureFunc: config,
 	}
@@ -100,11 +111,17 @@ func config(r *schema.ResourceData) (interface{}, error) {
 	casterAPI := r.Get("caster_api_url")
 	id := r.Get("client_id")
 	sec := r.Get("client_secret")
-
-	if user == nil || pass == nil || auth == nil || playerTok == nil || vmAPI == nil || id == nil || sec == nil ||
-		playerAPI == nil || casterAPI == nil {
-		return nil, nil
+	scopesInterface := r.Get("client_scopes").([]interface{})
+	scopesList := make([]string, len(scopesInterface))
+	for i, v := range scopesInterface {
+		scopesList[i] = v.(string) // Convert each item to string
 	}
+	scopes := strings.Join(scopesList, ",")
+
+	// if user == nil || pass == nil || auth == nil || playerTok == nil || vmAPI == nil || id == nil || sec == nil ||
+	// 	playerAPI == nil || casterAPI == nil {
+	// 	return nil, nil
+	// }
 
 	m := make(map[string]string)
 	m["username"] = user.(string)
@@ -116,5 +133,6 @@ func config(r *schema.ResourceData) (interface{}, error) {
 	m["caster_api_url"] = casterAPI.(string)
 	m["client_id"] = id.(string)
 	m["client_secret"] = sec.(string)
+	m["client_scopes"] = scopes
 	return m, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -89,9 +89,12 @@ func Provider() *schema.Provider {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Required: true,
+				Optional: true,
 				DefaultFunc: func() (interface{}, error) {
-					return os.Getenv("SEI_CRUCIBLE_CLIENT_SCOPES"), nil
+					if val := os.Getenv("SEI_CRUCIBLE_CLIENT_SCOPES"); val != "" {
+						return val, nil
+					}
+					return []interface{}{}, nil // Return an empty list if the environment variable is not set
 				},
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -118,10 +118,10 @@ func config(r *schema.ResourceData) (interface{}, error) {
 	}
 	scopes := strings.Join(scopesList, ",")
 
-	// if user == nil || pass == nil || auth == nil || playerTok == nil || vmAPI == nil || id == nil || sec == nil ||
-	// 	playerAPI == nil || casterAPI == nil {
-	// 	return nil, nil
-	// }
+	if user == nil || pass == nil || auth == nil || playerTok == nil || vmAPI == nil || id == nil || sec == nil ||
+		playerAPI == nil || casterAPI == nil || scopesInterface == nil {
+		return nil, nil
+	}
 
 	m := make(map[string]string)
 	m["username"] = user.(string)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -24,9 +24,12 @@ func ToStringSlice(data *[]interface{}) *[]string {
 
 // GetAuth gets an auth token.
 func GetAuth(m map[string]string) (string, error) {
+	scopes := strings.Split(m["client_scopes"], ",")
+
 	con := &oauth2.Config{
 		ClientID:     m["client_id"],
 		ClientSecret: m["client_secret"],
+		Scopes:       scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  m["auth_url"],
 			TokenURL: m["player_token_url"],

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,6 +26,10 @@ func ToStringSlice(data *[]interface{}) *[]string {
 func GetAuth(m map[string]string) (string, error) {
 	scopes := strings.Split(m["client_scopes"], ",")
 
+	if len(scopes) == 0 || (len(scopes) == 1 && scopes[0] == "") {
+		scopes = nil
+	}
+
 	con := &oauth2.Config{
 		ClientID:     m["client_id"],
 		ClientSecret: m["client_secret"],


### PR DESCRIPTION
Ran into an issue when using Authentik as my SSO provider using this module as Authentik won't automatically add scopes to a token unless they are requested, this pull request aims to fix that by allowing the user to define scopes to add to the token.

Had some issues with trying to handle if client_scopes is not defined so just left it as required.