### PR TITLE
Add crucible_player_application_template data source

### DIFF
--- a/docs/data-sources/player_application_template.md
+++ b/docs/data-sources/player_application_template.md
@@ -8,7 +8,7 @@ description: |-
 
 Looks up an application template in Crucible's Player API by name and exposes its `id` (and other fields). Use this to reference an existing template by its friendly name instead of hardcoding its UUID, for example when wiring an `application` block inside a `crucible_player_view`.
 
-The Player API does not provide a lookup-by-name endpoint, so this data source lists all templates and filters client-side. Template names are not guaranteed to be unique; if more than one template matches the given name, the lookup fails. It also fails if no template matches.
+Template names are not guaranteed to be unique; if more than one template matches the given name, the lookup fails. It also fails if no template matches.
 
 ## Example Usage
 

--- a/docs/data-sources/player_application_template.md
+++ b/docs/data-sources/player_application_template.md
@@ -1,0 +1,42 @@
+---
+page_title: "crucible_player_application_template Data Source"
+description: |-
+  Looks up an application template in the Crucible Player API by name.
+---
+
+# crucible_player_application_template
+
+Looks up an application template in Crucible's Player API by name and exposes its `id` (and other fields). Use this to reference an existing template by its friendly name instead of hardcoding its UUID, for example when wiring an `application` block inside a `crucible_player_view`.
+
+The Player API does not provide a lookup-by-name endpoint, so this data source lists all templates and filters client-side. Template names are not guaranteed to be unique; if more than one template matches the given name, the lookup fails. It also fails if no template matches.
+
+## Example Usage
+
+```hcl
+data "crucible_player_application_template" "vms" {
+  name = "Virtual Machines"
+}
+
+resource "crucible_player_view" "player" {
+  name   = "Example View"
+  status = "Active"
+
+  application {
+    name            = "VMs"
+    app_template_id = data.crucible_player_application_template.vms.id
+  }
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) The name of the application template to look up.
+- `case_insensitive` - (Optional) Whether to match the name ignoring case. Defaults to `false` (exact, case-sensitive match).
+
+## Attribute Reference
+
+- `id` - The UUID of the matched application template.
+- `url` - The URL the application template points to.
+- `icon` - The URL to the template's icon image.
+- `embeddable` - Whether the template is embeddable.
+- `load_in_background` - Whether the template loads in the background.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,10 @@ The Crucible provider enables [Terraform](https://www.terraform.io/) to manage r
 - [`crucible_player_view_network`](resources/player_view_network.md) — Manage allowed team networks in the VM API
 - [`crucible_vlan`](resources/vlan.md) — Acquire and release VLANs in the Caster API
 
+## Data Sources
+
+- [`crucible_player_application_template`](data-sources/player_application_template.md) — Look up an application template by name in the Player API
+
 ## Authentication
 
 The provider authenticates using OAuth2 resource owner password credentials. Credentials can be supplied via environment variables or directly in the provider block.

--- a/internal/api/player_api_application_template.go
+++ b/internal/api/player_api_application_template.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -159,6 +160,56 @@ func AppTemplateExists(id string, m map[string]string) (bool, error) {
 	}
 	// The current API returns 200 with an empty body for a missing template.
 	return resp.JSON200 != nil, nil
+}
+
+// AppTemplateFindByName returns the application template whose name matches the
+// given name. The Player API has no get-by-name endpoint, so this lists all
+// templates and filters client-side. Player does not enforce unique template
+// names, so this errors if more than one matches; it also errors if none match.
+// When caseInsensitive is true, matching uses strings.EqualFold.
+//
+// It returns the generated client struct (not structs.AppTemplate) so callers
+// can read the template's id, which structs.AppTemplate does not carry.
+func AppTemplateFindByName(name string, caseInsensitive bool, m map[string]string) (*playerclient.ApplicationTemplate, error) {
+	client, err := playerclient.NewAuthed(m)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetApplicationTemplatesWithResponse(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("player API returned with status code %d when listing templates", resp.StatusCode())
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("player API returned status 200 with no body when listing templates")
+	}
+
+	return matchAppTemplateByName(*resp.JSON200, name, caseInsensitive)
+}
+
+// matchAppTemplateByName returns the single template whose name matches; it
+// errors when zero or more than one match. Kept separate from the HTTP call so
+// the 0/1/many and case-insensitive logic can be unit tested without a server.
+func matchAppTemplateByName(templates []playerclient.ApplicationTemplate, name string, caseInsensitive bool) (*playerclient.ApplicationTemplate, error) {
+	var matches []playerclient.ApplicationTemplate
+	for _, t := range templates {
+		tName := derefStr(t.Name)
+		if (caseInsensitive && strings.EqualFold(tName, name)) || tName == name {
+			matches = append(matches, t)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no application template found with name %q", name)
+	case 1:
+		return &matches[0], nil
+	default:
+		return nil, fmt.Errorf("found %d application templates with name %q; names are not unique, look up by id instead", len(matches), name)
+	}
 }
 
 // fromAppTemplate maps a generated ApplicationTemplate onto the provider struct.

--- a/internal/api/player_api_application_template.go
+++ b/internal/api/player_api_application_template.go
@@ -162,32 +162,39 @@ func AppTemplateExists(id string, m map[string]string) (bool, error) {
 	return resp.JSON200 != nil, nil
 }
 
-// AppTemplateFindByName returns the application template whose name matches the
-// given name. The Player API has no get-by-name endpoint, so this lists all
-// templates and filters client-side. Player does not enforce unique template
-// names, so this errors if more than one matches; it also errors if none match.
-// When caseInsensitive is true, matching uses strings.EqualFold.
+// AppTemplateFindByName returns the id and provider-facing model of the
+// application template whose name matches the given name. The Player API has no
+// get-by-name endpoint, so this lists all templates and filters client-side.
+// Player does not enforce unique template names, so this errors if more than one
+// matches; it also errors if none match. When caseInsensitive is true, matching
+// uses strings.EqualFold.
 //
-// It returns the generated client struct (not structs.AppTemplate) so callers
-// can read the template's id, which structs.AppTemplate does not carry.
-func AppTemplateFindByName(name string, caseInsensitive bool, m map[string]string) (*playerclient.ApplicationTemplate, error) {
+// The id is returned separately because structs.AppTemplate does not carry it.
+func AppTemplateFindByName(name string, caseInsensitive bool, m map[string]string) (string, *structs.AppTemplate, error) {
 	client, err := playerclient.NewAuthed(m)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
 	resp, err := client.GetApplicationTemplatesWithResponse(context.Background())
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("player API returned with status code %d when listing templates", resp.StatusCode())
+		return "", nil, fmt.Errorf("player API returned with status code %d when listing templates", resp.StatusCode())
 	}
 	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("player API returned status 200 with no body when listing templates")
+		return "", nil, fmt.Errorf("player API returned status 200 with no body when listing templates")
 	}
 
-	return matchAppTemplateByName(*resp.JSON200, name, caseInsensitive)
+	match, err := matchAppTemplateByName(*resp.JSON200, name, caseInsensitive)
+	if err != nil {
+		return "", nil, err
+	}
+	if match.Id == nil {
+		return "", nil, fmt.Errorf("player API returned a template with no id")
+	}
+	return match.Id.String(), fromAppTemplate(match), nil
 }
 
 // matchAppTemplateByName returns the single template whose name matches; it

--- a/internal/api/player_api_application_template_test.go
+++ b/internal/api/player_api_application_template_test.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/cmu-sei/terraform-provider-crucible/internal/playerclient"
+)
+
+func TestMatchAppTemplateByName(t *testing.T) {
+	tmpl := func(name string) playerclient.ApplicationTemplate {
+		n := name
+		return playerclient.ApplicationTemplate{Name: &n}
+	}
+	templates := []playerclient.ApplicationTemplate{
+		tmpl("VMs"),
+		tmpl("Maps"),
+		tmpl("Console"),
+		tmpl("Console"), // intentional duplicate
+	}
+
+	tests := []struct {
+		name            string
+		lookup          string
+		caseInsensitive bool
+		wantName        string
+		wantErr         bool
+	}{
+		{name: "single exact match", lookup: "VMs", wantName: "VMs"},
+		{name: "no match", lookup: "Nope", wantErr: true},
+		{name: "duplicate names error", lookup: "Console", wantErr: true},
+		{name: "case-sensitive miss", lookup: "vms", wantErr: true},
+		{name: "case-insensitive hit", lookup: "vms", caseInsensitive: true, wantName: "VMs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := matchAppTemplateByName(templates, tt.lookup, tt.caseInsensitive)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result %+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.Name == nil || *got.Name != tt.wantName {
+				t.Fatalf("got %+v, want name %q", got, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/provider/cleanup_test.go
+++ b/internal/provider/cleanup_test.go
@@ -186,19 +186,14 @@ func vlanLabel(number int) string {
 }
 
 // captureID returns a TestCheckFunc that records a resource's Terraform state id
-// into out, so cleanup can delete it even after state is gone. attrKey selects
-// which attribute to capture ("" => the resource's primary id).
-func captureID(res, attrKey string, out *string) resource.TestCheckFunc {
+// into out, so cleanup can delete it even after state is gone.
+func captureID(res string, out *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[res]
 		if !ok {
 			return nil // resource not in state (e.g. step errored) — nothing to capture
 		}
-		if attrKey == "" {
-			*out = rs.Primary.ID
-		} else {
-			*out = rs.Primary.Attributes[attrKey]
-		}
+		*out = rs.Primary.ID
 		return nil
 	}
 }

--- a/internal/provider/player_app_template_data_source_test.go
+++ b/internal/provider/player_app_template_data_source_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+package provider_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccAppTemplateDataSource verifies the crucible_player_application_template
+// data source resolves a template by name to the same id as the backing
+// resource. The data source references the resource's name, so Terraform creates
+// the template first and the data source reads it back in the same apply.
+//
+// It also exercises the case_insensitive flag: a second data source looks the
+// template up by an upper-cased name and must resolve to the same id. (A default,
+// case-sensitive lookup of a mismatched case would error; that path is covered by
+// the dedicated not-found test below.)
+func TestAccAppTemplateDataSource(t *testing.T) {
+	var templateID string
+	registerAppTemplateCleanup(t, &templateID)
+
+	const name = "acc-ds-template"
+	config := fmt.Sprintf(`
+resource "crucible_player_application_template" "test" {
+	name = "%s"
+}
+
+data "crucible_player_application_template" "by_name" {
+	name = crucible_player_application_template.test.name
+}
+
+data "crucible_player_application_template" "by_name_ci" {
+	name             = upper(crucible_player_application_template.test.name)
+	case_insensitive = true
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTemplateDestroyed("crucible_player_application_template.test"),
+		Steps: []resource.TestStep{
+			{
+				Config: tfConfig(config),
+				Check: resource.ComposeTestCheckFunc(
+					captureID("crucible_player_application_template.test", "", &templateID),
+					// Exact, case-sensitive lookup resolves to the backing resource's id.
+					resource.TestCheckResourceAttrPair(
+						"data.crucible_player_application_template.by_name", "id",
+						"crucible_player_application_template.test", "id"),
+					resource.TestCheckResourceAttr(
+						"data.crucible_player_application_template.by_name", "name", name),
+					resource.TestCheckResourceAttr(
+						"data.crucible_player_application_template.by_name", "embeddable", "false"),
+					resource.TestCheckResourceAttr(
+						"data.crucible_player_application_template.by_name", "load_in_background", "false"),
+					// Case-insensitive lookup of an upper-cased name resolves to the same id.
+					resource.TestCheckResourceAttrPair(
+						"data.crucible_player_application_template.by_name_ci", "id",
+						"crucible_player_application_template.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAppTemplateDataSourceNotFound asserts the data source errors (rather
+// than returning empty state) when no template matches the given name. No
+// backing resource is created, so there is nothing to clean up.
+func TestAccAppTemplateDataSourceNotFound(t *testing.T) {
+	const config = `
+data "crucible_player_application_template" "missing" {
+	name = "acc-ds-template-does-not-exist"
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      tfConfig(config),
+				ExpectError: regexp.MustCompile("no application template found"),
+			},
+		},
+	})
+}

--- a/internal/provider/player_app_template_data_source_test.go
+++ b/internal/provider/player_app_template_data_source_test.go
@@ -47,7 +47,7 @@ data "crucible_player_application_template" "by_name_ci" {
 			{
 				Config: tfConfig(config),
 				Check: resource.ComposeTestCheckFunc(
-					captureID("crucible_player_application_template.test", "", &templateID),
+					captureID("crucible_player_application_template.test", &templateID),
 					// Exact, case-sensitive lookup resolves to the backing resource's id.
 					resource.TestCheckResourceAttrPair(
 						"data.crucible_player_application_template.by_name", "id",

--- a/internal/provider/player_app_template_test.go
+++ b/internal/provider/player_app_template_test.go
@@ -39,7 +39,7 @@ func TestAccAppTemplate(t *testing.T) {
 			{
 				Config: tfConfig(configAppTemplate),
 				Check: resource.ComposeTestCheckFunc(
-					captureID("crucible_player_application_template.test", "", &templateID),
+					captureID("crucible_player_application_template.test", &templateID),
 					resource.TestCheckResourceAttr("crucible_player_application_template.test", "name", "TestTemplate"),
 					resource.TestCheckResourceAttr("crucible_player_application_template.test", "url", "http://example.com"),
 					resource.TestCheckResourceAttr("crucible_player_application_template.test", "icon", "https://upload.wikimedia.org/wikipedia/en/thumb/9/9e/Buffalo_Sabres_Logo.svg/1200px-Buffalo_Sabres_Logo.svg.png"),
@@ -85,7 +85,7 @@ func TestAccAppTemplateOmittedFieldsStable(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tfConfig(appTemplateMinimalConfig("acc-min-template")),
-				Check:  captureID("crucible_player_application_template.minimal", "", &templateID),
+				Check:  captureID("crucible_player_application_template.minimal", &templateID),
 			},
 			{
 				// Edit name (a sibling); the omitted url/icon/embeddable/
@@ -125,7 +125,7 @@ func TestAccAppTemplateDetectsExternalDelete(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tfConfig(appTemplateMinimalConfig("acc-extdel-template")),
-				Check:  captureID("crucible_player_application_template.minimal", "", &templateID),
+				Check:  captureID("crucible_player_application_template.minimal", &templateID),
 			},
 			{
 				// Delete the template out of band, then re-plan the same config.

--- a/internal/provider/player_application_template_data_source.go
+++ b/internal/provider/player_application_template_data_source.go
@@ -1,0 +1,136 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cmu-sei/terraform-provider-crucible/internal/api"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ datasource.DataSource              = &applicationTemplateDataSource{}
+	_ datasource.DataSourceWithConfigure = &applicationTemplateDataSource{}
+)
+
+// applicationTemplateDataSource is the data source implementation for
+// crucible_player_application_template. It looks up an application template by
+// name and exposes its id (plus the rest of the template fields), letting
+// configs reference templates by name instead of hardcoded UUIDs.
+type applicationTemplateDataSource struct {
+	cfg map[string]string
+}
+
+type applicationTemplateDataSourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	URL              types.String `tfsdk:"url"`
+	Icon             types.String `tfsdk:"icon"`
+	Embeddable       types.Bool   `tfsdk:"embeddable"`
+	LoadInBackground types.Bool   `tfsdk:"load_in_background"`
+	CaseInsensitive  types.Bool   `tfsdk:"case_insensitive"`
+}
+
+// NewApplicationTemplateDataSource is a helper to instantiate the data source.
+func NewApplicationTemplateDataSource() datasource.DataSource {
+	return &applicationTemplateDataSource{}
+}
+
+func (d *applicationTemplateDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_player_application_template"
+}
+
+func (d *applicationTemplateDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	cfg, ok := req.ProviderData.(map[string]string)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Configuration Type",
+			fmt.Sprintf("Expected map[string]string, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.cfg = cfg
+}
+
+func (d *applicationTemplateDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			// case_insensitive defaults to false: matching is exact by default
+			// so existing lookups are not silently broadened. Set it to true to
+			// match the name ignoring case.
+			"case_insensitive": schema.BoolAttribute{
+				Optional: true,
+			},
+			"url": schema.StringAttribute{
+				Computed: true,
+			},
+			"icon": schema.StringAttribute{
+				Computed: true,
+			},
+			"embeddable": schema.BoolAttribute{
+				Computed: true,
+			},
+			"load_in_background": schema.BoolAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (d *applicationTemplateDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config applicationTemplateDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	template, err := api.AppTemplateFindByName(config.Name.ValueString(), config.CaseInsensitive.ValueBool(), d.cfg)
+	if err != nil {
+		resp.Diagnostics.AddError("Error looking up application template", err.Error())
+		return
+	}
+
+	if template.Id == nil {
+		resp.Diagnostics.AddError("Error looking up application template", "player API returned a template with no id")
+		return
+	}
+	config.ID = types.StringValue(template.Id.String())
+	config.Name = types.StringValue(strDeref(template.Name))
+	config.URL = types.StringValue(strDeref(template.Url))
+	config.Icon = types.StringValue(strDeref(template.Icon))
+	config.Embeddable = types.BoolValue(boolDeref(template.Embeddable))
+	config.LoadInBackground = types.BoolValue(boolDeref(template.LoadInBackground))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+// strDeref returns the pointed-to string, or "" if the pointer is nil.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// boolDeref returns the pointed-to bool, or false if the pointer is nil.
+func boolDeref(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}

--- a/internal/provider/player_application_template_data_source.go
+++ b/internal/provider/player_application_template_data_source.go
@@ -99,38 +99,18 @@ func (d *applicationTemplateDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	template, err := api.AppTemplateFindByName(config.Name.ValueString(), config.CaseInsensitive.ValueBool(), d.cfg)
+	id, template, err := api.AppTemplateFindByName(config.Name.ValueString(), config.CaseInsensitive.ValueBool(), d.cfg)
 	if err != nil {
 		resp.Diagnostics.AddError("Error looking up application template", err.Error())
 		return
 	}
 
-	if template.Id == nil {
-		resp.Diagnostics.AddError("Error looking up application template", "player API returned a template with no id")
-		return
-	}
-	config.ID = types.StringValue(template.Id.String())
-	config.Name = types.StringValue(strDeref(template.Name))
-	config.URL = types.StringValue(strDeref(template.Url))
-	config.Icon = types.StringValue(strDeref(template.Icon))
-	config.Embeddable = types.BoolValue(boolDeref(template.Embeddable))
-	config.LoadInBackground = types.BoolValue(boolDeref(template.LoadInBackground))
+	config.ID = types.StringValue(id)
+	config.Name = types.StringValue(template.Name)
+	config.URL = types.StringValue(template.URL)
+	config.Icon = types.StringValue(template.Icon)
+	config.Embeddable = types.BoolValue(template.Embeddable)
+	config.LoadInBackground = types.BoolValue(template.LoadInBackground)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
-}
-
-// strDeref returns the pointed-to string, or "" if the pointer is nil.
-func strDeref(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
-// boolDeref returns the pointed-to bool, or false if the pointer is nil.
-func boolDeref(b *bool) bool {
-	if b == nil {
-		return false
-	}
-	return *b
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -173,8 +173,9 @@ func (p *crucibleProvider) Resources(_ context.Context) []func() resource.Resour
 	}
 }
 
-// DataSources returns the data source types implemented by the provider. The
-// provider currently exposes no data sources.
+// DataSources returns the data source types implemented by the provider.
 func (p *crucibleProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return nil
+	return []func() datasource.DataSource{
+		NewApplicationTemplateDataSource,
+	}
 }


### PR DESCRIPTION
 ### Summary

  Adds a read-only data source that looks up a Player **application template** by name and exposes its `id` (plus `url`, `icon`, `embeddable`, `load_in_background`). This lets configs reference templates by their 
  friendly name instead of hardcoding UUIDs.

  Today, an `application` block inside a `crucible_player_view` requires a hardcoded `app_template_id` UUID (see `test/main.tf`). With this data source you can resolve the id by name:

  ```hcl
  data "crucible_player_application_template" "vms" {
    name = "Virtual Machines"
  }

  resource "crucible_player_view" "player" {
    name   = "Example View"
    status = "Active"

    application {
      name            = "VMs"
      app_template_id = data.crucible_player_application_template.vms.id
    }
  }
  ```

  Behavior

  - Exact, case-sensitive match by default. An optional case_insensitive = true opts into case-insensitive matching — strict by default so existing lookups are never silently broadened.
  - Errors on 0 matches ("no application template found with name ...") and on >1 match (template names are not unique in Player; the error suggests looking up by id instead).

  Implementation notes

  - New API helper AppTemplateFindByName returns (id, *structs.AppTemplate, error), routing through the existing fromAppTemplate mapper — the data source maps fields exactly like the existing resource's read(), with no
  duplicated nil-handling.
  - The 0/1/many + case-insensitive filtering is factored into a pure matchAppTemplateByName helper so it can be unit-tested without a live server.
  - Data source mirrors the existing resource's Configure/Metadata/schema conventions; registered in provider.DataSources().

  Files changed

  - internal/api/player_api_application_template.go — AppTemplateFindByName + matchAppTemplateByName
  - internal/provider/player_application_template_data_source.go — the data source
  - internal/provider/provider.go — register the data source
  - internal/api/player_api_application_template_test.go — unit tests (single / none / duplicate / case-insensitive)
  - internal/provider/player_app_template_data_source_test.go — acceptance tests (id-pair match, case-insensitive, not-found)
  - docs/data-sources/player_application_template.md + docs/index.md — docs